### PR TITLE
Use $(..) instead of legacy `..`

### DIFF
--- a/ahtapot-portscan/var/opt/portscan/parser.sh
+++ b/ahtapot-portscan/var/opt/portscan/parser.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 #parser.sh
 
-source `find /var/opt -name portscan.conf`
-DATE=`date +%F`
+source $(find /var/opt -name portscan.conf)
+DATE=$(date +%F)
 touch $LOG_DIR/alarm.log
 compare()
 {	previous_scan=$1
 	target=$2
-	ip_adresleri=`cat $previous_scan | grep Up | sort -u  | egrep -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}'`
+	ip_adresleri=$(cat $previous_scan | grep Up | sort -u  | egrep -o '([0-9]{1,3}[\.]){3}[0-9]{1,3}')
 	while IFS= read -r line 
 	do				
 		ip_adresi=$line
 	        cat $previous_scan  | grep -e "\<$ip_adresi\>" | grep -o '[0-9]*\/open/\tcp' | sed 's/\/open.*//' | sed 's/ $//g' | sort -n >  tcp_tarama.txt
 	        cat $previous_scan  | grep -e "\<$ip_adresi\>" | grep -o '[0-9]*\/open/\udp' | sed 's/\/open.*//' | sed 's/ $//g' | sort -n >  udp_tarama.txt
-		port_from_alarm=`sqlite3 $DB_DIR/db.ahtapotps "SELECT tcp,udp FROM portscan_alarm WHERE ip_address='$ip_adresi';"`
-		port_from_whitelist=`sqlite3 $DB_DIR/db.ahtapotps "SELECT tcp,udp  FROM portscan_assetlist WHERE ip_address='$ip_adresi';"`
+		port_from_alarm=$(sqlite3 $DB_DIR/db.ahtapotps "SELECT tcp,udp FROM portscan_alarm WHERE ip_address='$ip_adresi';")
+		port_from_whitelist=$(sqlite3 $DB_DIR/db.ahtapotps "SELECT tcp,udp  FROM portscan_assetlist WHERE ip_address='$ip_adresi';")
 		db_stat2=$?
 		if [ "$db_stat2" -eq 0 ];then
 			if ! [ -z "$port_from_whitelist" ] ;then
 				echo "$port_from_whitelist" | awk '{split($0,p,"|"); print p[1]}' | tr ',' '\n' | sed '/^\s*$/d' | sort -n >  tcp_veritabani.txt 
 				echo "$port_from_whitelist" | awk '{split($0,p,"|"); print p[2]}' | tr ',' '\n' | sed '/^\s*$/d' | sort -n >  udp_veritabani.txt
-				alarm_tcp_port=`comm -13 tcp_veritabani.txt tcp_tarama.txt | tr '\n' ',' | sed 's/,$//'`  
-				alarm_udp_port=`comm -13 udp_veritabani.txt udp_tarama.txt | tr '\n' ',' | sed 's/,$//'`
+				alarm_tcp_port=$(comm -13 tcp_veritabani.txt tcp_tarama.txt | tr '\n' ',' | sed 's/,$//')
+				alarm_udp_port=$(comm -13 udp_veritabani.txt udp_tarama.txt | tr '\n' ',' | sed 's/,$//')
 				
                 		if ! [ -z "$alarm_tcp_port" ];then
 					echo "$DATE::Alert::$target::Bu network'te bulunan $ip_adresi IP adresine ait $alarm_tcp_port numarali TCP port/portlar whitelist'te degildir." >> $LOG_DIR/alarm.log
@@ -53,9 +53,9 @@ compare()
 
 
 pushd $OUTPUT_DIR
-paths=`find . -name previous-scan`
+paths=$(find . -name previous-scan)
 echo "$paths" | while read -r path
 do
-	target=`echo "$path" | cut -d '/' -f3`
+	target=$(echo "$path" | cut -d '/' -f3)
 	compare "$path" $target
 done

--- a/ahtapot-portscan/var/opt/portscan/scanner.sh
+++ b/ahtapot-portscan/var/opt/portscan/scanner.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #scanner.sh
 
-source `find /var/opt -name portscan.conf`
+source $(find /var/opt -name portscan.conf)
 OPTIONS="-Pn -T4 -sSU -n -p- -d --min-rate 7000 --max-scan-delay 1ms --max-retries 1 --min-hostgroup 1024 --min-parallelism 256"
-DATE=`date +%s`                         
+DATE=$(date +%s)
 OUTPUT="-oA"                                
-NMAP=`which nmap`
+NMAP=$(which nmap)
 IPV4_REGEX="\b(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b"
 NETMASK_REGEX="\b([1-9]|[1-2][0-9]|3[0-2])\b"
 
@@ -17,7 +17,7 @@ while getopts "t:" opt; do
 	;;
 	esac
 done
-if ! [ `pwd` = "$LOG_DIR" ];then
+if ! [ $(pwd) = "$LOG_DIR" ];then
 	pushd $LOG_DIR
 fi
 touch portscan.log
@@ -25,8 +25,8 @@ chown ahtapotops:ahtapotops portscan.log
 # birden fazla TARGET degiskeni kullanilacaksa, aralaria virgul koyulmali
 echo "$TARGETS" | tr ',' '\n' | grep -v '^$' | while read -r TARGET
 do 
-	netmask=`echo "$TARGET" | cut -d "/" -f2`
-	address=`echo "$TARGET" | cut -d "/" -f1`
+	netmask=$(echo "$TARGET" | cut -d "/" -f2)
+	address=$(echo "$TARGET" | cut -d "/" -f1)
 	if ! [[ $address =~ $IPV4_REGEX ]];then
 		echo "Hedef adres 192.168.0.1/22 şeklinde belirtilmeli, sadece sayi ve nokta(.) kullanilmali" >> $LOG_DIR/portscan.log
 		exit 11;
@@ -49,7 +49,7 @@ do
 	fi
 	pushd "$netmask/$address"
 	$NMAP $TARGET $OPTIONS $OUTPUT scan-$DATE 
-	nmap_exit_status=`echo $?`
+	nmap_exit_status=$(echo $?)
 	echo "nmap_exit_status: $nmap_exit_status"
 	if [ "$nmap_exit_status" -eq 0 ];then
 	        echo "$DATE::$TARGET::Tarama bitti" >> $LOG_DIR/portscan.log


### PR DESCRIPTION
Backtick command substitution `..` is legacy syntax
with several issues:
    * It has a series of undefined behaviors
      related to quoting in POSIX.
    * It imposes a custom escaping mode with
      surprising results.
    * It's exceptionally hard to nest.

$(..) command substitution has none of these problems,
and is therefore strongly encouraged.

See also: https://github.com/koalaman/shellcheck/wiki/SC2006